### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/helm/aws-peering-tags-operator/values.yaml
+++ b/helm/aws-peering-tags-operator/values.yaml
@@ -13,7 +13,7 @@ image:
   name: "giantswarm/aws-peering-tags-operator"
   tag: "[[ .Version ]]"
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
 
 pod:
   user:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
